### PR TITLE
fix: Stop cloning as soon as namespace is reached

### DIFF
--- a/R/collector.R
+++ b/R/collector.R
@@ -122,8 +122,8 @@ collect_and_run <- function() {
 #   value they have at evaluation time
 env_clone_lazy <- function(env) {
   # we stop the recursion when we find a special env, defined by having a name
-  if (env_name(env) != "") return(env)
 
+  if (!env_name(env) %in% c("", "global")) return(env)
   parent_clone <- env_clone_lazy(env_parent(env))
   clone <- rlang::env_clone(env, parent = parent_clone)
   # don't touch dots or bindings that are already lazy
@@ -140,7 +140,7 @@ env_clone_lazy <- function(env) {
 
 # drop lazy bindings, since these were not used
 env_cleanup <- function(env) {
-  if (env_name(env) != "") return(env)
+  if (!env_name(env) %in% c("", "global")) return(env)
   env_cleanup(env_parent(env))
   lazy_lgl <- env_binding_are_lazy(env)
   rm(list = names(lazy_lgl)[lazy_lgl], envir = env)

--- a/R/collector.R
+++ b/R/collector.R
@@ -122,7 +122,8 @@ collect_and_run <- function() {
 #   value they have at evaluation time
 env_clone_lazy <- function(env) {
   # we stop the recursion when we find a special env, defined by having a name
-  if (!is.null(attr(env, "name")) || identical(env, emptyenv())) return(env)
+  if (env_name(env) != "") return(env)
+
   parent_clone <- env_clone_lazy(env_parent(env))
   clone <- rlang::env_clone(env, parent = parent_clone)
   # don't touch dots or bindings that are already lazy
@@ -139,7 +140,7 @@ env_clone_lazy <- function(env) {
 
 # drop lazy bindings, since these were not used
 env_cleanup <- function(env) {
-  if (!is.null(attr(env, "name")) || identical(env, emptyenv())) return(env)
+  if (env_name(env) != "") return(env)
   env_cleanup(env_parent(env))
   lazy_lgl <- env_binding_are_lazy(env)
   rm(list = names(lazy_lgl)[lazy_lgl], envir = env)


### PR DESCRIPTION
Closes #8.

``` r
Sys.setenv(COLLECTOR_PATH = ".")
library(comperes)

get_matchups(ncaa2005)
#> # A widecr object:
#> # A tibble: 40 × 5
#>     game player1 score1 player2 score2
#>    <int> <chr>    <int> <chr>    <int>
#>  1     1 Duke         7 Duke         7
#>  2     1 Duke         7 Miami       52
#>  3     1 Miami       52 Duke         7
#>  4     1 Miami       52 Miami       52
#>  5     2 Duke        21 Duke        21
#>  6     2 Duke        21 UNC         24
#>  7     2 UNC         24 Duke        21
#>  8     2 UNC         24 UNC         24
#>  9     3 Duke         7 Duke         7
#> 10     3 Duke         7 UVA         38
#> # ℹ 30 more rows

callr::r(function() {
  Sys.setenv(COLLECTOR_PATH = "")
  data <- qs::qread("3-mutate.qs")

  get("mutate", data$env)
})
#> function(.data, ...) {
#>   UseMethod("mutate")
#> }
#> <bytecode: 0x105b7c700>
#> <environment: namespace:dplyr>
```

<sup>Created on 2024-04-19 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>