### PR TITLE
fix: Clear attributes of call to conserve memory

### DIFF
--- a/R/collector.R
+++ b/R/collector.R
@@ -109,10 +109,11 @@ collect_and_run <- function() {
   exec_env <- parent.frame()
   caller_env <- parent.frame(2)
   is_called_by_own_ns <- identical(topenv(caller_env), topenv(exec_env))
-  call = sys.call(-1)
+  call <- sys.call(-1)
+  attributes(call) <- NULL
   original <- attr(sys.function(-1), "unmodified")
   call_to_original <- call
-  call_to_original[[1]] <-  original[[1]]
+  call_to_original[[1]] <- original[[1]]
   if (is_called_by_own_ns) {
     return(eval(call_to_original, caller_env))
   }
@@ -121,7 +122,6 @@ collect_and_run <- function() {
   on.exit({
     globals$i <- globals$i + 1
     env_cleanup(new_caller_env)
-    attributes(call) <- NULL
     suppressWarnings(qs::qsave(
       file = sprintf("%s/%.5d-%s.qs", globals$path, globals$i, names(original)),
       list(

--- a/R/collector.R
+++ b/R/collector.R
@@ -121,6 +121,7 @@ collect_and_run <- function() {
   on.exit({
     globals$i <- globals$i + 1
     env_cleanup(new_caller_env)
+    attributes(call) <- NULL
     suppressWarnings(qs::qsave(
       file = sprintf("%s/%.5d-%s.qs", globals$path, globals$i, names(original)),
       list(


### PR DESCRIPTION
Closes #15.

``` r
Sys.setenv(COLLECTOR_PATH = ".")
options(conflicts.policy = list(warn = FALSE))
library(dplyr)

data.frame(a = 1) %>%
  filter(a == 1) %>%
  mutate(b = 2) %>%
  select(a)
#>   a
#> 1 1

data.frame(a = 1) |>
  filter(a == 1) |>
  mutate(b = 2) |>
  select(a)
#>   a
#> 1 1

d1 <- data.frame(a = 1)
d2 <- filter(d1, a == 1)
d3 <- mutate(d2, b = 2)
d4 <- select(d3, a)

fs::dir_info(glob = "*.qs")[1:3]
#> # A tibble: 9 × 3
#>   path            type         size
#>   <fs::path>      <fct> <fs::bytes>
#> 1 00001-filter.qs file          239
#> 2 00002-mutate.qs file          258
#> 3 00003-select.qs file          244
#> 4 00004-filter.qs file          217
#> 5 00005-mutate.qs file          239
#> 6 00006-select.qs file          242
#> 7 00007-filter.qs file          231
#> 8 00008-mutate.qs file          232
#> 9 00009-select.qs file          228
```

<sup>Created on 2024-04-24 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>